### PR TITLE
Comment out option 'sqlalchemy.use_native_unicode=False' for config.ini (deployment.ini_tmpl) default. 

### DIFF
--- a/zookeepr/config/deployment.ini_tmpl
+++ b/zookeepr/config/deployment.ini_tmpl
@@ -52,8 +52,9 @@ host_name = localhost
 # SQLAlchemy database URL
 sqlalchemy.url = sqlite:///%(here)s/development.db
 sqlalchemy.convert_unicode = true
-sqlalchemy.use_native_unicode=False
 
+# for us with PostgreSQL
+# sqlalchemy.use_native_unicode=False
 
 # WARNING: *THE LINE BELOW MUST BE UNCOMMENTED ON A PRODUCTION ENVIRONMENT*
 # Debug mode will enable the interactive debugging tool, allowing ANYONE to


### PR DESCRIPTION
Also added comment that this option should only be used for postgreSQL users.

This configuration option was causing installation pain, per the discussion on the mailing list and this solution suggested by James Iseppi.

My first pull request please be kind :)
