### PR TITLE
Add a new manual incomplete account creation page for organizers

### DIFF
--- a/zookeepr/config/routing.py
+++ b/zookeepr/config/routing.py
@@ -84,6 +84,7 @@ def make_map(config):
     map.connect('/person/reset_password/{url_hash}', controller='person', action='reset_password')
     map.connect('/person/persona_login',             controller='person', action='persona_login')
     map.connect('/person/finish_signup',             controller='person', action='finish_signup')
+    map.connect('/person/new_incomplete',            controller='person', action='new_incomplete')
 
     # booklet
     map.connect('/registration/professionals_latex', controller='registration', action='professionals_latex')

--- a/zookeepr/templates/person/list.mako
+++ b/zookeepr/templates/person/list.mako
@@ -35,6 +35,8 @@
 % endfor
 </table>
 
+<p><a href="${ h.url_for(controller='person', action='new_incomplete') }">Create a new account</a></p>
+
 <%def name="title()">
 People -
  ${ parent.title() }

--- a/zookeepr/templates/person/new_incomplete.mako
+++ b/zookeepr/templates/person/new_incomplete.mako
@@ -1,0 +1,21 @@
+<%inherit file="/base.mako" />
+<%
+    c.form = 'new_incomplete'
+%>
+<h2 class="pop">Creation of a new incomplete user account</h2>
+
+<p>This form allows organizers to manually create incomplete accounts for other people.</p>
+
+<p>These accounts can be assigned roles or edited but they will not have a password associated with them. The ownwer of that email address will have to use Persona to log in or request a password reset via email.</p>
+
+${ h.form(h.url_for(), method='post') }
+
+<p class="label"><span class="mandatory">*</span><label for="person.email_address">Email address:</label></p>
+<p class="entries">${ h.text('person.email_address', size=40) }</p>
+
+<p class="label"><span class="mandatory">*</span><label for="person.email_address2">Confirm the email address:</label></p>
+<p class="entries">${ h.text('person.email_address2', size=40) }</p>
+
+<p class="submit">${ h.submit("submit", "Create a new account",) }</p>
+
+${ h.end_form() }


### PR DESCRIPTION
This will speed up the workflow for admins wanting to give someone
an account with a particular role.

For example:

1- organizer creates new account for a sponsor's email address
2- organizer gives role of sponsor to that new account
3- organizer tells sponsor to register for conf
4- sponsor logs into zookeepr using Persona (or asks for a
   password reset via email)
5- sponsor register for the conference
6- sponsor is overwhelmed by the awesomeness of this process
