### PR TITLE
Fix the colour of the Persona button text when unfocussed

### DIFF
--- a/zk/public/css/persona.css
+++ b/zk/public/css/persona.css
@@ -51,6 +51,7 @@
 }
 
 .persona-button span{
+	color: #ffffff;
 	display: inline-block;
 	padding: 5px 10px 5px 40px;
 }


### PR DESCRIPTION
This seems to only affect the LCA2013 theme for some reason, but it should be safe to enable globally.
