### PR TITLE
Fix url_for hash addition

### DIFF
--- a/zkpylons/lib/helpers.py
+++ b/zkpylons/lib/helpers.py
@@ -521,10 +521,9 @@ def redirect_to(*args, **kargs):
 
 def url_for(*args, **kwargs):
     fields = dict(request.GET)
-    extra = ''
-    if fields.has_key('hash'):
-        extra='?hash=' + fields['hash']
-    return pylons_url_for(*args, **kwargs) + extra
+    if fields.has_key('hash') and 'hash' not in kwargs:
+        kwargs['hash'] = fields['hash']
+    return pylons_url_for(*args, **kwargs)
 
 def list_to_string(list, primary_join='%s and %s', secondary_join=', ', html = False):
     if html:


### PR DESCRIPTION
- Don't arbitrarily append strings to the end of the URL.
- Instead add what we want added to kwargs so that url_for sorts it out for us
