### PR TITLE
Add missing external dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,6 +4,10 @@ Zookeepr Installation Instructions
 External dependencies
 ---------------------
 
+ * libpq-dev
+ * libpython-dev
+ * libxslt1-dev
+ * libxml2-dev
  * postgresql
      
     


### PR DESCRIPTION
This is what I needed to install in order to make `python setup.py develop` work.