### PR TITLE
Replace PBKDF2 with SHA-256 (fix #336)

### DIFF
--- a/plugins/php-auth/auth.php
+++ b/plugins/php-auth/auth.php
@@ -31,7 +31,10 @@ function check_password($email, $password) {
     pg_close($dbconn);
     print "\t ZK:\t" . $expectedhash . "\n";
 
-    $computedhash = hash_pbkdf2('sha256', $password, $ZKSALT . $usersalt, $ZKITERATIONS);
+    $salt = $ZKSALT . $usersalt;
+    // FIXME: switch back to PBKDF2 once Python 2.7.8 is in Ubuntu LTS (16.04)
+    //$computedhash = hash_pbkdf2('sha256', $password, $salt, $ZKITERATIONS);
+    $computedhash = hash('sha256', $password . $salt);
     print "\t PHP:\t" . $computedhash . "\n";
 
     return $expectedhash === $computedhash;

--- a/zk/model/person.py
+++ b/zk/model/person.py
@@ -119,8 +119,12 @@ class Person(Base):
             self.password_salt = salt.hexdigest()
 
         salt = lca_info['password_salt'] + self.password_salt
-        dk = hashlib.pbkdf2_hmac('sha256', value, salt, lca_info['password_iterations'])
-        return binascii.hexlify(dk)
+        # FIXME: switch back to PBKDF2 once Python 2.7.8 is in Ubuntu LTS (16.04)
+        #dk = hashlib.pbkdf2_hmac('sha256', value, salt, lca_info['password_iterations'])
+        #return binascii.hexlify(dk)
+        h = hashlib.new('sha256')
+        h.update(value + salt)
+        return h.hexdigest()
 
     def _set_password(self, value):
         if value is not None:


### PR DESCRIPTION
Ubuntu 14.04 doesn't have Python 2.7.8 (where pbkdf2 got added) :(