### PR TITLE
Fix bug reported by dtbell - reviewer cannot load

### DIFF
--- a/zkpylons/templates/angular.mako
+++ b/zkpylons/templates/angular.mako
@@ -3,6 +3,8 @@
 <%def name="short_title()"></%def>
 <%def name="toolbox_extra()"></%def>
 <%def name="toolbox_extra_admin()"></%def>
+<%def name="toolbox_extra_reviewer()"></%def>
+<%def name="toolbox_extra_funding_reviewer()"></%def>
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html lang="en-us">
 	<head>


### PR DESCRIPTION
Angular template did not provide define structures for the reviewer or
funding reviewer which is used by the toolbox template.