### PR TITLE
Fix missing postal code error

### DIFF
--- a/zkpylons/controllers/person.py
+++ b/zkpylons/controllers/person.py
@@ -459,7 +459,7 @@ class PersonController(BaseController): #Read, Update, List
             if Config.get('personal_info', category='rego')['home_address'] == 'no':
                 defaults['person.address1'] = 'not available'
                 defaults['person.city'] = 'not available'
-                defaults['person.postcode'] = 'not available'
+                defaults['person.postcode'] = 'none'
 
             c.social_networks = SocialNetwork.find_all()
 

--- a/zkpylons/controllers/registration.py
+++ b/zkpylons/controllers/registration.py
@@ -329,7 +329,7 @@ class RegistrationController(BaseController):
         if Config.get('personal_info', category='rego')['home_address'] == 'no':
             defaults['person.address1'] = 'not available'
             defaults['person.city'] = 'not available'
-            defaults['person.postcode'] = 'not available'
+            defaults['person.postcode'] = 'none'
 
         if c.signed_in_person:
             for k in ['address1', 'address2', 'city', 'state', 'postcode', 'country', 'phone', 'mobile', 'company', 'i_agree']:


### PR DESCRIPTION
When testing zookeepr, I noticed that conference registration doesn't work when the address requirement is set to "no" in the configuration. This looks to be because the default value entered in the db is too long for validation. I believe this patch fixes the issue.