### PR TITLE
Fix travis/tox issues on remote server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 # command to install dependencies
 install: "pip install tox"
 # command to run tests
-script: tox -e $TOX_ENV
+script: tox -c tox.pip18.ini -e $TOX_ENV
 addons:
   postgresql: 9.3
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 # command to install dependencies
 install: "pip install tox"
 # command to run tests
-script: tox -c tox.pip18.ini -e $TOX_ENV
+script: tox -c tox.pip6.ini -e $TOX_ENV
 addons:
   postgresql: 9.3
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv = VIRTUAL_ENV={envdir}
          LANGUAGE=en_US:en
          LC_ALL=C
 usedevelop = True
-install_command = pip install --allow-external PIL --allow-unverified PIL --allow-external elementtree --allow-unverified elementtree --find-links=http://effbot.org/downloads {opts} {packages}
+install_command = pip install --upgrade --find-links=http://effbot.org/downloads {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 

--- a/tox.pip6.ini
+++ b/tox.pip6.ini
@@ -1,0 +1,43 @@
+# New versions of pip require the --trusted-host parameter
+# otherwise they die hard.
+# Old versions of pip die hard if --trusted-host is present.
+#
+# Standard virtualenv such as Debian's uses an old version of pip
+# travis-ci.org which we use for acceptance testing uses a new version
+#
+# The only solution I have managed to come up with is to have two files.
+# One providing a config for each system.
+#   tox.ini is the default and set for the old pip versions
+#   tox.pip18.ini is for new pip versions and is used by .travis.yml
+
+[tox]
+envlist = py27
+
+[testenv]
+setenv = VIRTUAL_ENV={envdir}
+         LANG=en_US.UTF-8
+         LANGUAGE=en_US:en
+         LC_ALL=C
+usedevelop = True
+install_command = pip install --find-links=http://effbot.org/downloads --trusted-host=effbot.org {opts} {packages}
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
+[testenv:py27]
+commands = python -m pytest
+
+[testenv:pep8]
+commands = flake8 {posargs}
+
+[testenv:cover]
+commands = python setup.py testr --coverage {posargs}
+
+[testenv:venv]
+commands = {posargs}
+
+[testenv:pserve]
+commands = pserve --reload development.ini {posargs}
+
+[flake8]
+show-source = True
+exclude = .venv,.tox,dist,doc,build,*.egg,zkpylons,zk,alembic,data


### PR DESCRIPTION
New versions of pip require the --trusted-host parameter
otherwise they die hard.
Old versions of pip die hard if --trusted-host is present.

Standard virtualenv such as Debian's uses an old version of pip
travis-ci.org which we use for acceptance testing uses a new version

The only solution I have managed to come up with is to have two files.
One providing a config for each system.
  tox.ini is the default and set for the old pip versions
  tox.pip18.ini is for new pip versions and is used by .travis.yml